### PR TITLE
Add current SOCKS price and available SOCKS

### DIFF
--- a/src/components/Socks/index.tsx
+++ b/src/components/Socks/index.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
+import { TokenAmount } from '@uniswap/sdk'
+import { useActiveWeb3React } from '../../hooks'
 import Unisocks1img from '../../assets/images/unisocks1.png'
+import { SOCKS } from '../../constants'
 import styled from 'styled-components'
+import useUSDCPrice from '../../utils/useUSDCPrice'
+import { useTotalSupply } from '../../data/TotalSupply'
 
 
 const SocksContainer = styled.div`
@@ -44,13 +49,19 @@ const SocksStatsAvailable = styled.div`
 `
 
 export default function Socks() {
+  const { chainId } = useActiveWeb3React()
+  const socks = chainId ? SOCKS : undefined
+  const socksPrice = useUSDCPrice(socks)
+  const totalSupply: TokenAmount | undefined = useTotalSupply(socks)
+
+
   return (
     <SocksContainer>
         <ImageTop src={Unisocks1img} />
-      <SocksPrice>$ PRICE HERE USD</SocksPrice>
+      <SocksPrice>Current SOCKS Price: ${socksPrice?.toFixed(2).replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') ?? '-'}</SocksPrice>
       <SocksStats>
-        <SocksStatsRedeem>🔥123 redeemed</SocksStatsRedeem>
-        <SocksStatsAvailable>123 Available</SocksStatsAvailable>
+        <SocksStatsRedeem>🔥</SocksStatsRedeem>
+        <SocksStatsAvailable>Currently there are {totalSupply?.toFixed(0, { groupSeparator: ',' })} SOCKS available</SocksStatsAvailable>
       </SocksStats>
     </SocksContainer>
   )


### PR DESCRIPTION
This commit uses the price / availability info from SocksBalanceContent to display the current SOCKS price and availability on the home page. Removed the text from SocksStatsRedeem for now.
<img width="1440" alt="Screen Shot 2021-02-03 at 9 55 30 AM" src="https://user-images.githubusercontent.com/59103702/106773360-96c10080-6606-11eb-8609-d348bc300036.png">
<img width="1440" alt="Screen Shot 2021-02-03 at 9 55 04 AM" src="https://user-images.githubusercontent.com/59103702/106773387-9d4f7800-6606-11eb-9b7b-9da189ce9edc.png">

