### PR TITLE
Add SOCKS redeemed, Update Stats modal, and Remove Extra stats modal

### DIFF
--- a/src/components/Header/SocksRedeemContent.tsx
+++ b/src/components/Header/SocksRedeemContent.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { X } from 'react-feather'
 import styled from 'styled-components'
 import { TYPE } from '../../theme'
@@ -8,6 +8,7 @@ import { CardBGImage, CardNoise, CardSection, DataCard } from '../earn/styled'
 import { ButtonLight } from '../../components/Button'
 import Unisocks1img from '../../assets/images/unisocks1.png'
 import Checkmark from '../../assets/images/checkmark.png'
+import { useActiveWeb3React } from '../../hooks'
 
 const ContentWrapper = styled(AutoColumn)`
   width: 100%;
@@ -72,17 +73,59 @@ const RedeemedTitle = styled.h1`
   text-align: center;
   color: #FF007A;
 `
-const formState = true
+const formShowing = false
+
+const qty = 'qty'
+const nameSurname = 'nameSurname'
+const addressLine1 = 'addressLine1'
+const city = 'city'
+const stateProvinceRegion = 'stateProvinceRegion'
+const zipPostCode = 'zipPostCode'
+const country = 'country'
+const emailAddress = 'emailAddress'
+const ethAddress = 'ethAddress'
+const timeStamp = 'timeStamp'
+
+const nameMap = {
+  [qty]: 'QTY',
+  [nameSurname]: 'Name and Surname',
+  [addressLine1]: 'Address Line 1',
+  [city]: 'City',
+  [stateProvinceRegion]: 'State / Province / Region',
+  [zipPostCode]: 'Zip / Post Code',
+  [country]: 'Country',
+  [emailAddress]: 'Email Address',
+  [ethAddress]: 'Ethereum Address',
+  [timeStamp]: 'Time'
+}
+
+const defaultState = {
+  [qty]: Number,
+  [nameSurname]: '',
+  [addressLine1]: '',
+  [city]: '',
+  [stateProvinceRegion]: '',
+  [zipPostCode]: '',
+  [country]: '',
+  [emailAddress]: ''
+}
 
 
 /**
  * Content for balance stats modal
  */
 export default function SocksBalanceContent({ setShowSocksRedeemModal }: { setShowSocksRedeemModal: any }) {
-
+  const { library } = useActiveWeb3React()
+  const [formState, setFormState] = useState(defaultState)
+   
+  function handleChange(event: { target: { name: any; value: any } }) {
+    const { name, value } = event.target
+    setFormState(state => ({ ...state, [name]: value }))
+  }
+ 
   return (
     <ContentWrapper gap="lg">
-    <div hidden={formState}>
+    <div hidden={formShowing}>
       <ModalUpper>
         <CardBGImage />
         <CardNoise />
@@ -100,22 +143,62 @@ export default function SocksBalanceContent({ setShowSocksRedeemModal }: { setSh
             </ModalHeader>
             <RowBetween>
             <TYPE.white color="white">🧦 Socks QTY</TYPE.white>
-            <TYPE.white color="white">NUM</TYPE.white>
+            <input type="number" name={qty} value={formState[qty].toString()}
+                onChange={handleChange} placeholder={nameMap[qty]}></input>
             </RowBetween>
               <RowBetween>
               <form>
                 <label><TYPE.white color="white">Where should we send them?</TYPE.white>
-                <InputField placeholder="Name and surname"></InputField>
-                <InputField placeholder="Address Line 1"></InputField>
-                <InputField placeholder="City"></InputField>
-                <InputField placeholder="State/Province/Region"></InputField>
-                <InputField placeholder="ZIP/Postcode"></InputField>
-                <InputField placeholder="Country"></InputField>
-                <InputField placeholder="Email address"></InputField>
+                <InputField name={nameSurname} value={formState[nameSurname]}
+                onChange={handleChange} placeholder={nameMap[nameSurname]}></InputField>
+                <InputField name={addressLine1} value={formState[addressLine1]}
+                onChange={handleChange} placeholder={nameMap[addressLine1]}></InputField>
+                <InputField name={city} value={formState[city]}
+                onChange={handleChange} placeholder={nameMap[city]}></InputField>
+                <InputField name={stateProvinceRegion} value={formState[stateProvinceRegion]}
+                onChange={handleChange} placeholder={nameMap[stateProvinceRegion]}></InputField>
+                <InputField name={zipPostCode} value={formState[zipPostCode]}
+                onChange={handleChange} placeholder={nameMap[zipPostCode]}></InputField>
+                <InputField name={country} value={formState[country]}
+                onChange={handleChange} placeholder={nameMap[country]}></InputField>
+                <InputField name={emailAddress} value={formState[emailAddress]}
+                onChange={handleChange} placeholder={nameMap[emailAddress]}></InputField>
                 </label>
               </form>
               </RowBetween>
-              <ButtonLight onClick={()=>{}}>Confirm purchase</ButtonLight>
+              <ButtonLight onClick={ 
+                async () => {
+                const signer = library.getSigner()
+                //const timestampToSign = Math.round(Date.now() / 1000)
+                const header = `PLEASE VERIFY YOUR ADDRESS.\nYour data will never be shared publicly.`
+                const formDataMessage = `
+                  ${nameMap[nameSurname]}: ${formState[nameSurname]}
+                  ${nameMap[addressLine1]}: ${formState[addressLine1]}
+                  ${nameMap[city]}: ${formState[city]}
+                  ${nameMap[stateProvinceRegion]}: ${formState[stateProvinceRegion]}
+                  ${nameMap[zipPostCode]}: ${formState[zipPostCode]}
+                  ${nameMap[country]}: ${formState[country]}
+                  ${nameMap[emailAddress]}: ${formState[emailAddress]}
+                  ${nameMap[qty]} : ${formState[qty]}
+                `
+                console.log(formDataMessage)
+                const autoMessage = '' // TODO
+
+                var signature = await signer
+                  .signMessage(`${header}\n\n${formDataMessage}\n${autoMessage}`)
+
+                // Will probably need to pass in actual URL of endpoint instead of '/'
+                await fetch('/', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: '' // TODO encode
+                })
+
+                console.log(signature)
+              }
+              }>
+                Confirm purchase
+              </ButtonLight>
             </AutoColumn>
           </CardSection>
           </ModalUpper>

--- a/src/components/Header/SocksStatsContent.tsx
+++ b/src/components/Header/SocksStatsContent.tsx
@@ -6,7 +6,8 @@ import tokenLogo from '../../assets/images/socks-logo.png'
 import { SOCKS } from '../../constants'
 import { useTotalSupply } from '../../data/TotalSupply'
 import { useActiveWeb3React } from '../../hooks'
-import { ExternalLink, TYPE, UniTokenAnimated } from '../../theme'
+import { ExternalLink, StyledInternalLink, TYPE, UniTokenAnimated } from '../../theme'
+import useUSDCPrice from '../../utils/useUSDCPrice'
 import { AutoColumn } from '../Column'
 import { RowBetween } from '../Row'
 import { CardBGImage, CardNoise, CardSection, DataCard } from '../earn/styled'
@@ -39,14 +40,16 @@ export default function SocksBalanceContent({ setShowSocksStatsModal }: { setSho
   const socks = chainId ? SOCKS : undefined
   const totalSupply: TokenAmount | undefined = useTotalSupply(socks)
 
+  const socksPrice = useUSDCPrice(socks)
+
   return (
     <ContentWrapper gap="lg">
       <ModalUpper>
         <CardBGImage />
         <CardNoise />
-        <CardSection gap="md">
+        <CardSection gap="md" style={{justifySelf: "center"}}>
           <RowBetween>
-            <TYPE.white color="white">SOCKS Stats</TYPE.white>
+            <TYPE.white color="white">Your 🧦 Stats</TYPE.white>
             <StyledClose stroke="white" onClick={() => setShowSocksStatsModal(false)} />
           </RowBetween>
         </CardSection>
@@ -67,19 +70,31 @@ export default function SocksBalanceContent({ setShowSocksStatsModal }: { setSho
         <CardSection gap="sm">
           <AutoColumn gap="md">
             <RowBetween>
-              <TYPE.white color="white">🧦 Initial SOCKS</TYPE.white>
-              <TYPE.white color="white">NUM</TYPE.white>
+              <TYPE.white color="white">🧦 Price:
+</TYPE.white>
+<TYPE.white color="white">${socksPrice?.toFixed(2).replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') ?? '-'}</TYPE.white>
             </RowBetween>
             <RowBetween>
-              <TYPE.white color="white">🔥 Redeem SOCKS</TYPE.white>
-              <TYPE.white color="white">NUM</TYPE.white>
+            <TYPE.white color="white">🧦 Available</TYPE.white>
+              <TYPE.white color="white">{totalSupply?.toFixed(0, { groupSeparator: ',' })}</TYPE.white>
             </RowBetween>
             <RowBetween>
-              <TYPE.white color="white">💦 SOCKS Pool</TYPE.white>
-              <TYPE.white color="white">NUM</TYPE.white>
+              <TYPE.white color="white">🧦 Redeemed</TYPE.white>
+              <TYPE.white color="white">🔥{500 - Number(totalSupply?.toFixed(0, { groupSeparator: ',' }))}</TYPE.white>
+            </RowBetween>
+            <RowBetween>
+            <StyledInternalLink onClick={() => setShowSocksStatsModal(false)} to="/swap?exactField=output&outputCurrency=0x23b608675a2b2fb1890d3abbd85c5775c51691d5">
+              <TYPE.white color="white">BUY</TYPE.white>
+            </StyledInternalLink>
+            <ExternalLink href="https://unisocks.exchange">
+              <TYPE.white color="white">REDEEM</TYPE.white>
+            </ExternalLink>
+            <StyledInternalLink onClick={() => setShowSocksStatsModal(false)} to="/swap?exactField=input&inputCurrency=0x23b608675a2b2fb1890d3abbd85c5775c51691d5">
+              <TYPE.white color="white">SELL</TYPE.white>
+            </StyledInternalLink>
             </RowBetween>
             {socks && socks.chainId === ChainId.MAINNET ? (
-              <ExternalLink href={`https://uniswap.info/token/${socks.address}`}><TYPE.white color="white">View 🧦 Analytics</TYPE.white></ExternalLink>
+              <ExternalLink style={{justifySelf: "center", marginTop: "10px"}} href={`https://uniswap.info/token/${socks.address}`}><TYPE.white color="white">View 🧦 Analytics</TYPE.white></ExternalLink>
             ) : null}
           </AutoColumn>
         </CardSection>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,30 +1,23 @@
-import { ChainId, TokenAmount } from '@uniswap/sdk'
+import { ChainId } from '@uniswap/sdk'
 import React, { useState } from 'react'
 import { Text } from 'rebass'
 import { NavLink } from 'react-router-dom'
 import { darken } from 'polished'
-
 import styled from 'styled-components'
 import Logo from '../../assets/svg/logo-dark.svg'
 import LogoDark from '../../assets/svg/logo-white.svg'
 import { useActiveWeb3React } from '../../hooks'
 import { useDarkModeManager } from '../../state/user/hooks'
-import { useETHBalances, useAggregateSocksBalance } from '../../state/wallet/hooks'
-import { CardNoise } from '../earn/styled'
-import { CountUp } from 'use-count-up'
-import { TYPE, ExternalLink } from '../../theme'
-
+import { useETHBalances } from '../../state/wallet/hooks'
+import { ExternalLink } from '../../theme'
 import { YellowCard } from '../Card'
 import Settings from '../Settings'
 import Menu from '../Menu'
-
 import Row, { RowFixed } from '../Row'
 import Web3Status from '../Web3Status'
 import Modal from '../Modal'
-import SocksBalanceContent from './SocksBalanceContent'
 import SocksStatsContent from './SocksStatsContent'
 import SocksRedeemContent from './SocksRedeemContent'
-import usePrevious from '../../hooks/usePrevious'
 
 const HeaderFrame = styled.div`
   display: grid;
@@ -121,29 +114,6 @@ const AccountElement = styled.div<{ active: boolean }>`
   /* :hover {
     background-color: ${({ theme, active }) => (!active ? theme.bg2 : theme.bg4)};
   } */
-`
-
-const UNIAmount = styled(AccountElement)`
-  color: white;
-  padding: 4px 8px;
-  height: 36px;
-  font-weight: 500;
-  background-color: ${({ theme }) => theme.bg3};
-  background: radial-gradient(174.47% 188.91% at 1.84% 0%, #ff007a 0%, #2172e5 100%), #edeef2;
-`
-
-const UNIWrapper = styled.span`
-  width: fit-content;
-  position: relative;
-  cursor: pointer;
-
-  :hover {
-    opacity: 0.8;
-  }
-
-  :active {
-    opacity: 0.9;
-  }
 `
 
 const HideSmall = styled.span`
@@ -263,23 +233,13 @@ const NETWORK_LABELS: { [chainId in ChainId]?: string } = {
 
 export default function Header() {
   const { account, chainId } = useActiveWeb3React()
-
   const userEthBalance = useETHBalances(account ? [account] : [])?.[account ?? '']
   const [isDark] = useDarkModeManager()
-
-  const aggregateSocksBalance: TokenAmount | undefined = useAggregateSocksBalance()
-
-  const [showSocksBalanceModal, setShowSocksBalanceModal] = useState(false)
   const [showSocksStatsModal, setShowSocksStatsModal] = useState(false)
   const [showSocksRedeemModal, setShowSocksRedeemModal] = useState(false)
-  const countUpSocksValue = aggregateSocksBalance?.toFixed(0) ?? '0'
-  const countUpSocksValuePrevious = usePrevious(countUpSocksValue) ?? '0'
 
   return (
     <HeaderFrame>
-      <Modal isOpen={showSocksBalanceModal} onDismiss={() => setShowSocksBalanceModal(false)}>
-        <SocksBalanceContent setShowSocksBalanceModal={setShowSocksBalanceModal} />
-      </Modal>
       <Modal isOpen={showSocksStatsModal} onDismiss={() => setShowSocksStatsModal(false)}>
         <SocksStatsContent setShowSocksStatsModal={setShowSocksStatsModal} />
       </Modal>
@@ -311,32 +271,6 @@ export default function Header() {
               <NetworkCard title={NETWORK_LABELS[chainId]}>{NETWORK_LABELS[chainId]}</NetworkCard>
             )}
           </HideSmall>
-          {aggregateSocksBalance && (
-            <UNIWrapper onClick={() => setShowSocksBalanceModal(true)}>
-              <UNIAmount active={!!account} style={{ pointerEvents: 'auto' }}>
-                {account && (
-                  <HideSmall>
-                    <TYPE.white
-                      style={{
-                        paddingRight: '.4rem'
-                      }}
-                    >
-                      <CountUp
-                        key={countUpSocksValue}
-                        isCounting
-                        start={parseFloat(countUpSocksValuePrevious)}
-                        end={parseFloat(countUpSocksValue)}
-                        thousandsSeparator={','}
-                        duration={1}
-                      />
-                    </TYPE.white>
-                  </HideSmall>
-                )}
-                🧦
-              </UNIAmount>
-              <CardNoise />
-            </UNIWrapper>
-          )}
           <AccountElement active={!!account} style={{ pointerEvents: 'auto' }}>
             {account && userEthBalance ? (
               <BalanceText style={{ flexShrink: 0 }} pl="0.75rem" pr="0.5rem" fontWeight={500}>

--- a/src/components/Socks/index.tsx
+++ b/src/components/Socks/index.tsx
@@ -60,7 +60,7 @@ export default function Socks() {
         <ImageTop src={Unisocks1img} />
       <SocksPrice>Current SOCKS Price: ${socksPrice?.toFixed(2).replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1,') ?? '-'}</SocksPrice>
       <SocksStats>
-        <SocksStatsRedeem>🔥</SocksStatsRedeem>
+        <SocksStatsRedeem>🔥 {500 - Number(totalSupply?.toFixed(0, { groupSeparator: ',' }))} SOCKS Redeemed</SocksStatsRedeem>
         <SocksStatsAvailable>Currently there are {totalSupply?.toFixed(0, { groupSeparator: ',' })} SOCKS available</SocksStatsAvailable>
       </SocksStats>
     </SocksContainer>


### PR DESCRIPTION
This commit updates the redeemed socks on the main page (Socks/index.tsx), Updates the Header stats link to include the stats data when clicked, and removes the small stats button from the top right of the header.

![newStats](https://user-images.githubusercontent.com/59103702/106827911-ea573c80-664e-11eb-9461-a9117c69ff52.png)
![homePage](https://user-images.githubusercontent.com/59103702/106827922-f04d1d80-664e-11eb-90de-9f8b26b68dd4.png)

