### PR TITLE
Do not show import modal for socks token

### DIFF
--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -1,4 +1,4 @@
-import { CurrencyAmount, JSBI, Token, Trade } from '@uniswap/sdk'
+import { Currency, CurrencyAmount, JSBI, Token, Trade } from '@uniswap/sdk'
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { ArrowDown } from 'react-feather'
 import ReactGA from 'react-ga'
@@ -44,6 +44,7 @@ import { computeTradePriceBreakdown, warningSeverity } from '../../utils/prices'
 import AppBody from '../AppBody'
 import { ClickableText } from '../Pool/styleds'
 import Loader from '../../components/Loader'
+import { DEFAULTTOKEN } from '../../constants'
 
 export default function Swap() {
   const loadedUrlParams = useDefaultsFromURLSearch()
@@ -54,8 +55,16 @@ export default function Swap() {
     useCurrency(loadedUrlParams?.outputCurrencyId)
   ]
   const [dismissTokenWarning, setDismissTokenWarning] = useState<boolean>(false)
+
+  const isTokenOtherThanSocks = (currency: Currency) => {
+    if (currency instanceof Token) {
+      return currency.address.toLowerCase() !== DEFAULTTOKEN
+    }
+    return false
+  }
+
   const urlLoadedTokens: Token[] = useMemo(
-    () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => c instanceof Token) ?? [],
+    () => [loadedInputCurrency, loadedOutputCurrency]?.filter((c): c is Token => isTokenOtherThanSocks(c)) ?? [],
     [loadedInputCurrency, loadedOutputCurrency]
   )
   const handleConfirmTokenWarning = useCallback(() => {


### PR DESCRIPTION
Do not show import modal if the input/output token is Socks.

There might be a better way to test if two addresses are equal than using strings. If so, let me know and I will update this PR.

closes #7 